### PR TITLE
Add getFilename() method for descriptive image names

### DIFF
--- a/src/main/java/com/wdbyte/bing/Images.java
+++ b/src/main/java/com/wdbyte/bing/Images.java
@@ -36,6 +36,30 @@ public class Images {
         return String.format("![](%s)Today: [%s](%s)", smallUrl, desc, url);
     }
 
+    /**
+     * Generate a descriptive filename from the image description.
+     * Extracts the main subject from the copyright text.
+     * Example: "Short-beaked echidna, Adelaide Hills, Australia (© Etienne Littlefair/naturepl.com)"
+     * Returns: "2026-03-19-Short-beaked-echidna.jpg"
+     */
+    public String getFilename() {
+        String filename = date;
+        if (desc != null && !desc.isEmpty()) {
+            // Extract the main subject (before the first comma or parenthesis)
+            String subject = desc.split("[,(]")[0].trim();
+            // Make filename-safe by replacing special chars
+            subject = subject.replaceAll("[^a-zA-Z0-9\\s]", "")
+                           .replaceAll("\\s+", "-")
+                           .toLowerCase();
+            // Limit length to 50 chars
+            if (subject.length() > 50) {
+                subject = subject.substring(0, 50);
+            }
+            filename = date + "-" + subject;
+        }
+        return filename + ".jpg";
+    }
+
     public String getDesc() {
         return desc;
     }


### PR DESCRIPTION
## Summary

This PR adds a  method to the  class that generates descriptive filenames from image descriptions.

### Changes
- Added  method to  that:
  - Extracts the main subject from the copyright text (e.g., "Short-beaked echidna")
  - Creates filename-safe strings by replacing special characters
  - Limits filename length to 50 characters
  - Combines date and subject: 

### Example
**Input:** 
**Output:** 

This addresses issue #25: add short description to image names.

### Testing
The method handles edge cases:
- Empty or null descriptions: falls back to date-only filename
- Very long descriptions: truncated to 50 characters
- Special characters: removed or replaced with hyphens